### PR TITLE
go.mod: lower the go directive to 1.26.0 (a patch-level floor propagates to every consumer)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/wroge/wgs84/v2
 
-go 1.26.4
+go 1.26.0


### PR DESCRIPTION
`go.mod` has said `go 1.26.4` since the June `go mod tidy` (e7a0fd9; alpha.16 was
`go 1.26`). Since Go 1.21 the `go` line is a *minimum toolchain*, and the go command
requires every module that depends on wgs84 to declare a `go` line at least that high
— so the patch level propagates: `github.com/tdewolff/canvas` (which uses wgs84 in an
example) was raised to `go 1.26.4` by its own tidy, and from there every canvas user is
raised too (we hit it in `modernc.org/webview`, an HTML renderer built on canvas). A
consumer on Go 1.26.0–1.26.3 then fails to build with `GOTOOLCHAIN=local`, or is made to
download 1.26.4 with the default `auto` — for a floor nothing actually needs: a patch
release adds no language or library surface.

This restores the minor-version floor you had at alpha.16, in the modern form:

```
-go 1.26.4
+go 1.26.0
```

Checked on go1.27.0: `go build ./...`, `go vet ./...` clean, and `go mod tidy` keeps
`go 1.26.0` (wgs84 has no dependencies that could raise it). A tag after this lands
(alpha.19?) is what lets downstream pick it up — `go get` resolves the floor from the
tagged version's go.mod.

Thanks for wgs84.
