### PR TITLE
Apply the 1/B exponent to the whole quotient in SwissObliqueMercator

### DIFF
--- a/swiss_oblique.go
+++ b/swiss_oblique.go
@@ -167,7 +167,7 @@ func (som SwissObliqueMercator) ToGeographic(east, north, height float64, s Sphe
 
 	Up := (Vp*math.Cos(gamma0) + Sp*math.Sin(gamma0)) / Tp
 
-	tp := H / math.Pow(math.Sqrt((1+Up)/(1-Up)), 1.0/B)
+	tp := math.Pow(H/math.Sqrt((1+Up)/(1-Up)), 1.0/B)
 
 	chi := math.Pi/2 - 2*math.Atan(tp)
 

--- a/swiss_oblique_test.go
+++ b/swiss_oblique_test.go
@@ -1,0 +1,39 @@
+package wgs84
+
+import (
+	"math"
+	"testing"
+)
+
+func lv03() SwissObliqueMercator {
+	return SwissObliqueMercator{
+		Latf:   46.9524055555556,
+		Lonf:   7.43958333333333,
+		Scale:  1,
+		Eastf:  600000,
+		Northf: 200000,
+	}
+}
+
+func TestSwissObliqueMercatorFalseOrigin(t *testing.T) {
+	som, sp := lv03(), CH1903.Spheroid
+
+	lon, lat, _ := som.ToGeographic(som.Eastf, som.Northf, 0, sp)
+	if math.Abs(lon-som.Lonf) > 1e-9 || math.Abs(lat-som.Latf) > 1e-9 {
+		t.Errorf("false origin maps to %.9f %.9f, want %.9f %.9f", lon, lat, som.Lonf, som.Latf)
+	}
+}
+
+func TestSwissObliqueMercatorRoundTrip(t *testing.T) {
+	som, sp := lv03(), CH1903.Spheroid
+
+	for lon := 6.0; lon <= 10.5; lon += 0.25 {
+		for lat := 45.8; lat <= 47.9; lat += 0.25 {
+			east, north, _ := som.FromGeographic(lon, lat, 0, sp)
+			back, backLat, _ := som.ToGeographic(east, north, 0, sp)
+			if math.Abs(back-lon) > 1e-9 || math.Abs(backLat-lat) > 1e-9 {
+				t.Fatalf("%.4f %.4f round-trips to %.9f %.9f", lon, lat, back, backLat)
+			}
+		}
+	}
+}


### PR DESCRIPTION
`SwissObliqueMercator.ToGeographic` is not the inverse of `FromGeographic` — the round trip is off
by about 10 m across CH1903.

The projection's own false origin does not come back to itself:

```
ToGeographic(600000, 200000)  ->  lon=7.439583333  lat=46.952317892
declared origin              ->  lon=7.439583333  lat=46.952405556
                                                  latitude error: 9.76 m
```

Longitude is exact and only latitude is wrong, which points at the isometric-latitude exponent.

### Cause

`swiss_oblique.go:170` raises only the square root to `1/B`, leaving `H` outside:

```go
tp := H / math.Pow(math.Sqrt((1+Up)/(1-Up)), 1.0/B)
```

The forward in the same file fixes where the exponent belongs — `swiss_oblique.go:77`:

```go
Q := H / math.Pow(t, B)
```

Solving that for `t` gives `t = (H/Q)^(1/B)`, so the whole quotient takes the exponent. EPSG
Guidance Note 7-2 writes the reverse of method 9815 the same way:
`t' = {H / [((1+U')/(1–U'))^0.5]}^(1/B)`.

### Effect, next to the sibling projections

Worst round-trip error over the CH1903 area (`wgs84.go:172`), same harness for each:

```
SwissObliqueMercator   8.95e-05 deg   (~10 m)
TransverseMercator     7.72e-09 deg
```

`EPSG:21781` (LV03) and `EPSG:2056` (LV95) both use this type (`epsg.go:172`, `epsg.go:182`).

### Change

One expression:

```go
tp := math.Pow(H/math.Sqrt((1+Up)/(1-Up)), 1.0/B)
```

After it the false origin maps to itself exactly and the worst round-trip error over the same grid
is **1.7e-11 deg**, better than the other projections in the package.

### Tests

The repo has no test files, so `go test ./...` passes vacuously today. I have added
`swiss_oblique_test.go` with the false-origin assertion and a round-trip sweep over the CH1903 area
— red with only `swiss_oblique.go` reverted, green with the change. `gofmt -l` reports the same five
files before and after; `go vet` is clean.

This is the same class as #19 (Krovak), #20 (LambertConformalConic2SP) and #21 (TransverseMercator)
— SwissObliqueMercator looks like the one that was not revisited.

---

Disclosure: prepared with AI assistance; I verified the false-origin check, the round-trip
comparison against the sibling projections and the red/green runs myself.
